### PR TITLE
feat: Improve API for generating forwarding clients

### DIFF
--- a/impact_stack/rest/__init__.py
+++ b/impact_stack/rest/__init__.py
@@ -102,7 +102,9 @@ class ClientFactory:
         config = self.app_configs[app_slug]
         api_version = api_version or config["api_version"]
         path = posixpath.join("api", app_slug, api_version)
-        return config["class"](
+        if isinstance(client_class := config["class"], str):
+            client_class = utils.class_from_path(client_class)
+        return client_class(
             urllib.parse.urljoin(self.base_url, path),
             auth=auth,
             request_timeout=config["timeout"],

--- a/impact_stack/rest/exceptions.py
+++ b/impact_stack/rest/exceptions.py
@@ -1,0 +1,5 @@
+"""Define custom exception classes."""
+
+
+class RequestUnauthorized(ValueError):
+    """Exception raised for attempts to create forwarding clients from unauthorized requests."""

--- a/impact_stack/rest/utils.py
+++ b/impact_stack/rest/utils.py
@@ -1,6 +1,13 @@
 """Define various helper functions."""
 
 import datetime
+import importlib
 
 # Proxy for datetime.now() so that it can be stubbed while testing.
 now = datetime.datetime.now
+
+
+def class_from_path(path: str):
+    """Import a class using its qualified name."""
+    module_path, class_name = path.rsplit(".", 1)
+    return getattr(importlib.import_module(module_path), class_name)

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -12,7 +12,7 @@ from impact_stack.rest import AuthMiddleware, ClientFactory
 
 def test_auth_client(app, requests_mock):
     """Test getting a token from the client app."""
-    client = ClientFactory.from_config(app.config.get).get_client("auth", needs_auth=False)
+    client = ClientFactory.from_config(app.config.get).get_client("auth")
     token_response = {
         "token": "TOKEN.org1",
         "data": {"exp": datetime.datetime.now().timestamp() + 3600},
@@ -27,7 +27,7 @@ def test_auth_client(app, requests_mock):
 
 def test_client_with_middleware(app, requests_mock):
     """Test sending authorized requests."""
-    client = ClientFactory.from_config(app.config.get).get_client("test", "v42")
+    client = ClientFactory.from_config(app.config.get).app_to_app("test", "v42")
     initial_time = datetime.datetime(2023, 9, 26, 13, 7)
     token_response = {
         "token": "TOKEN.org1",
@@ -67,6 +67,6 @@ def test_renewal_without_api_key(app, requests_mock):
     """Test that session renewal works without an API-key."""
     del app.config["IMPACT_STACK_API_KEY"]
     factory = ClientFactory.from_app()
-    client = factory.get_client("auth", needs_auth=False)
+    client = factory.get_client("auth")
     requests_mock.post("https://impact-stack.net/api/auth/v1/renew", json={"status": "ok"})
     assert client.post("renew", json_response=True) == {"status": "ok"}

--- a/tests/client_factory_test.py
+++ b/tests/client_factory_test.py
@@ -22,13 +22,32 @@ def test_override_timeout(app):
     factory = rest.ClientFactory.from_app()
     test_client_cls = mock.Mock()
     factory.app_configs["test"] = {**factory.app_configs["test"], **{"class": test_client_cls}}
-    factory.get_client("test", "v1", needs_auth=None)
+    factory.get_client("test", "v1")
     assert test_client_cls.mock_calls == [
         mock.call(app.config["IMPACT_STACK_API_URL"] + "/test/v1", auth=None, request_timeout=2),
     ]
     test_client_cls.reset_mock()
     factory.app_configs["test"]["timeout"] = 42
-    factory.get_client("test", "v1", needs_auth=None)
+    factory.get_client("test", "v1")
     assert test_client_cls.mock_calls == [
         mock.call(app.config["IMPACT_STACK_API_URL"] + "/test/v1", auth=None, request_timeout=42),
     ]
+
+
+@pytest.mark.usefixtures("app")
+def test_forwarding_client(requests_mock):
+    """Test that a forwarding client forwards the authorization header."""
+    requests_mock.get("https://impact-stack.net/api/test/v1/", json={"status": "ok"})
+    factory = rest.ClientFactory.from_app()
+
+    incoming_request = mock.Mock()
+    incoming_request.headers = {"Authorization": "Bearer JWT-token"}
+    client = factory.forwarding(incoming_request, "test", "v1")
+    assert client.get(json_response=True) == {"status": "ok"}
+    assert "Authorization" in requests_mock.request_history[0].headers
+    assert requests_mock.request_history[0].headers["Authorization"] == "Bearer JWT-token"
+
+    incoming_request = mock.Mock()
+    incoming_request.headers = {}
+    with pytest.raises(rest.exceptions.RequestUnauthorized):
+        factory.forwarding(incoming_request, "test", "v1")

--- a/tests/client_factory_test.py
+++ b/tests/client_factory_test.py
@@ -17,6 +17,17 @@ def test_override_class():
     assert isinstance(factory.get_client("test", "v1"), test_client_cls)
 
 
+@pytest.mark.usefixtures("app")
+def test_class_from_path():
+    """Test instantiating a client class by passing the class path as string."""
+    factory = rest.ClientFactory.from_app()
+    factory.app_configs["test"] = {
+        **factory.app_configs["test"],
+        **{"class": "impact_stack.rest.Client"},
+    }
+    assert isinstance(factory.get_client("test", "v1"), rest.Client)
+
+
 def test_override_timeout(app):
     """Test that clients can get specific default timeouts."""
     factory = rest.ClientFactory.from_app()


### PR DESCRIPTION
The ClientFactory now has 3 methods for creating clients:

- `get_client()` for creating client classes without auth or with custom authentication.
- `app_to_app()` for backend app-to-app requests with full admin access.
- `forwarding()` for sub-requests triggered while handling a browser initiated request.